### PR TITLE
[FASTLANE] Added adding device lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,6 +64,25 @@ platform :ios do
     # frameit
   end
 
+  lane :register_a_device do
+  register_devices(
+      devices: {
+        "device name": "uuid",
+        "another device name": "another uuid"
+      })
+    refresh_profiles
+  end
+
+  # A helper lane for refreshing provisioning profiles.
+  lane :refresh_profiles do
+    match(
+      type: "development",
+      force: true)
+    match(
+      type: "adhoc",
+      force: true)
+  end
+
   # You can define as many lanes as you want
 
   after_all do |lane|

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -46,6 +46,16 @@ This will also make sure the profile is up to date
 fastlane ios release
 ```
 Deploy a new version to the App Store
+### ios register_a_device
+```
+fastlane ios register_a_device
+```
+
+### ios refresh_profiles
+```
+fastlane ios refresh_profiles
+```
+
 
 ----
 

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,22 +5,22 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: Verifying required fastlane version" time="0.000496">
+      <testcase classname="fastlane.lanes" name="0: Verifying required fastlane version" time="0.000576">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: default_platform" time="0.000478">
+      <testcase classname="fastlane.lanes" name="1: default_platform" time="0.000271">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: gym" time="39.308436">
+      <testcase classname="fastlane.lanes" name="2: gym" time="46.122096">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: crashlytics" time="16.454374">
+      <testcase classname="fastlane.lanes" name="3: crashlytics" time="17.536241">
         
       </testcase>
     


### PR DESCRIPTION
Can now use `register_a_device` lane to register any new uuids.